### PR TITLE
Add Agent QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Please see [CONTRIBUTING](https://github.com/DhanushNehru/Ultimate-NodeJs-Resour
 - [Mocha](https://mochajs.org)
 - [Node Tap](https://node-tap.org)
 - [Sinon](https://sinonjs.org/)
+- [Agent QA](https://github.com/vostride/agent-qa)
 
 ## NodeJs YouTube channels
 - [Programming with Mosh](https://www.youtube.com/watch?v=uVwtVBpw7RQ)

--- a/frontend/views/src/data/resourcesLibrary.json
+++ b/frontend/views/src/data/resourcesLibrary.json
@@ -307,7 +307,8 @@
       {"id": "jest", "name": "Jest", "url": "https://jestjs.io", "type": "Library", "description": "Delightful JavaScript testing with mocking, snapshots, and watch mode.", "tags": ["testing", "unit", "library"]},
       {"id": "mocha", "name": "Mocha", "url": "https://mochajs.org", "type": "Library", "description": "Flexible Node.js test runner with async support and reporters.", "tags": ["testing", "runner", "library"]},
       {"id": "node-tap", "name": "Node Tap", "url": "https://node-tap.org", "type": "Library", "description": "Test Anything Protocol (TAP) harness for Node.js projects.", "tags": ["testing", "tap", "library"]},
-      {"id": "sinon", "name": "Sinon", "url": "https://sinonjs.org/", "type": "Library", "description": "Standalone test spies, stubs, and mocks for JavaScript.", "tags": ["testing", "mocks", "library"]}
+      {"id": "sinon", "name": "Sinon", "url": "https://sinonjs.org/", "type": "Library", "description": "Standalone test spies, stubs, and mocks for JavaScript.", "tags": ["testing", "mocks", "library"]},
+      {"id": "agent-qa", "name": "Agent QA", "url": "https://github.com/vostride/agent-qa", "type": "Tool", "description": "Node.js CLI for natural-language web and mobile testing, with execution memory and an MCP interface. Source-available under FSL-1.1-ALv2.", "tags": ["testing", "e2e", "mcp"]}
     ]
   },
   {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+  base = "frontend/views"
+  command = "npm run build"
+  publish = "dist"


### PR DESCRIPTION
Add Agent QA at the end of **NodeJs Testing Frameworks** in the README and in the website's matching resource data. It is an npm-distributed Node.js 24+ CLI for natural-language application testing; the data entry states its FSL-1.1-ALv2 source-available license.

Validation: the resource list grows from 107 to 108 entries, with all prior records unchanged and unique IDs. `npm ci` and `npm run build` pass. The actual ResourcesLibrary component renders the new record, and the served production JavaScript contains it. `npm run lint` reports three existing unused-variable errors in unchanged files (`eslint.config.js`, `ContentDisplay.jsx`, and `Sidebar.jsx`).

The first Netlify preview served the source `index.html` and uncompiled `/src/main.jsx` (as `application/octet-stream`). Add `netlify.toml` to build from `frontend/views` with `npm run build` and publish its `dist` directory, making the catalog available as a compiled site. The exact configured local build passes and produces bundled assets containing the new record.

One resource, one commit, and the requested `contributing` branch.

Affiliation: I maintain Agent QA. This contribution was prepared with AI assistance.
